### PR TITLE
Fix logos scale on responsive mode

### DIFF
--- a/carddrawer/src/main/java/com/meli/android/carddrawer/model/CardDrawerView.java
+++ b/carddrawer/src/main/java/com/meli/android/carddrawer/model/CardDrawerView.java
@@ -6,7 +6,6 @@ import android.graphics.drawable.GradientDrawable;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.support.annotation.ColorInt;
-import android.support.annotation.IdRes;
 import android.support.annotation.IntDef;
 import android.support.annotation.LayoutRes;
 import android.support.annotation.NonNull;

--- a/carddrawer/src/main/res/layout/card_drawer_card_issuer.xml
+++ b/carddrawer/src/main/res/layout/card_drawer_card_issuer.xml
@@ -4,5 +4,4 @@
     android:layout_width="wrap_content"
     android:layout_height="match_parent"
     android:scaleType="fitCenter"
-    android:adjustViewBounds="true"
     android:layout_gravity="end" />

--- a/carddrawer/src/main/res/layout/card_drawer_card_logo.xml
+++ b/carddrawer/src/main/res/layout/card_drawer_card_logo.xml
@@ -4,7 +4,6 @@
     android:layout_width="wrap_content"
     android:layout_height="match_parent"
     android:scaleType="fitCenter"
-    android:adjustViewBounds="true"
     android:layout_marginRight="8dp"
     android:layout_marginEnd="8dp"
     android:layout_gravity="start" />

--- a/carddrawer/src/main/res/layout/card_drawer_front.xml
+++ b/carddrawer/src/main/res/layout/card_drawer_front.xml
@@ -55,12 +55,10 @@
 
     <ImageSwitcher
         android:id="@+id/cho_card_logo"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
+        android:layout_width="wrap_content"
+        android:layout_height="@dimen/card_drawer_logo_height"
         app:layout_constraintStart_toStartOf="@id/card_header_front_guideline_left"
-        app:layout_constraintTop_toTopOf="@id/card_header_front_guideline_top"
-        app:layout_constraintDimensionRatio="W,77:44"
-        app:layout_constraintHeight_percent="0.278" >
+        app:layout_constraintTop_toTopOf="@id/card_header_front_guideline_top" >
 
         <include layout="@layout/card_drawer_card_logo" />
         <include layout="@layout/card_drawer_card_logo" />
@@ -69,10 +67,8 @@
 
     <ImageSwitcher
         android:id="@+id/cho_card_issuer"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_constraintHeight_percent="0.278"
-        app:layout_constraintDimensionRatio="W,77:44"
+        android:layout_width="wrap_content"
+        android:layout_height="@dimen/card_drawer_logo_height"
         app:layout_constraintEnd_toEndOf="@id/card_header_front_guideline_right"
         app:layout_constraintTop_toTopOf="@id/card_header_front_guideline_top" >
 

--- a/carddrawer/src/main/res/layout/card_drawer_front_lowres.xml
+++ b/carddrawer/src/main/res/layout/card_drawer_front_lowres.xml
@@ -54,10 +54,9 @@
 
     <ImageSwitcher
         android:id="@+id/cho_card_logo"
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="0dp"
         android:visibility="gone"
-        app:layout_constraintDimensionRatio="W,77:55"
         app:layout_constraintBottom_toTopOf="@id/card_header_front_guideline_middle"
         app:layout_constraintStart_toStartOf="@id/card_header_front_guideline_left"
         app:layout_constraintTop_toTopOf="@id/card_header_front_guideline_top" >

--- a/carddrawer/src/main/res/values/dimens.xml
+++ b/carddrawer/src/main/res/values/dimens.xml
@@ -7,5 +7,6 @@
     <dimen name="card_drawer_layout_padding">20dp</dimen>
 
     <dimen name="card_drawer_shadow_radius">2dp</dimen>
+    <dimen name="card_drawer_logo_height">44dp</dimen>
 
 </resources>


### PR DESCRIPTION
Los logos se veían muy grandes en responsive por estar ajustados porcentualmente, ahora nos quedamos con el tamaño fijo en dp. No debería afectar para nada como se ve el modo regular.