### PR TITLE
Feature/show back without anim

### DIFF
--- a/carddrawer/src/main/java/com/meli/android/carddrawer/model/CardDrawerView.java
+++ b/carddrawer/src/main/java/com/meli/android/carddrawer/model/CardDrawerView.java
@@ -200,6 +200,14 @@ public class CardDrawerView extends FrameLayout implements Observer {
         showSecCircle();
     }
 
+    /**
+     * Shows the back card without animation.
+     * Uses the saved card style or default
+     */
+    public void showBack() {
+        cardAnimator.switchViewWithoutAnimation(FieldPosition.POSITION_BACK);
+    }
+
     protected void setupImageSwitcher(final ImageSwitcher imageSwitcher, final Animation fadeIn, final Animation fadeOut) {
         imageSwitcher.setInAnimation(fadeIn);
         imageSwitcher.setOutAnimation(fadeOut);

--- a/carddrawer/src/test/java/com/meli/android/carddrawer/model/CardDrawerViewTest.java
+++ b/carddrawer/src/test/java/com/meli/android/carddrawer/model/CardDrawerViewTest.java
@@ -223,6 +223,24 @@ public class CardDrawerViewTest extends BasicRobolectricTest {
         assertEquals(View.VISIBLE, codeBack.getVisibility());
     }
 
+
+    @Test
+    public void showBack_callsSwitchViewWithoutAnimationUsesBackPosition() {
+        CardDrawerView spyHeader = spy(header);
+        GradientTextView codeFront = new GradientTextView(getContext());
+        codeFront.setVisibility(View.INVISIBLE);
+        TextView codeBack = new TextView((getContext()));
+        codeBack.setVisibility(View.INVISIBLE);
+        ReflectionHelpers.setField(spyHeader, "codeFront", codeFront);
+        ReflectionHelpers.setField(spyHeader, "codeBack", codeBack);
+        CardAnimator cardAnimatorMock = mock(CardAnimator.class);
+        ReflectionHelpers.setField(spyHeader, "cardAnimator", cardAnimatorMock);
+
+        spyHeader.showBack();
+
+        verify(cardAnimatorMock).switchViewWithoutAnimation(FieldPosition.POSITION_BACK);
+    }
+
     @Test
     public void hideSecCircle_withFrontPosition_hidesSecCode() {
         final CardUI source = mock(CardUI.class);

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ org.gradle.workers.max=8
 ##################################################################################
 
 libraryGroupId=com.mercadolibre.android
-libraryVersion=2.0.2
+libraryVersion=2.0.3
 
 ##################################################################################
 # Project setup


### PR DESCRIPTION
Usando la última versión de la lib noté que en CHO se agregó una animación rara al querer mostrar solo el dorso de la tarjeta para tarjetas precargadas. Después de analizar bien el problema, noté que se debia al cambio del secCode BACK en la DefaultConfiguración. Como esto no debería afectar a la animación, desde CHO surgió la necesidad de agregar este método para mostrar solo el dorso de la tarjeta.