### PR TITLE
[Enhancement] Improving of bottomDescription from BottomLabel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+_XX_04_2022
+* Enhancement bottomDescription and shadow of BottomLabel.
+
 ## Release 3.2.0
 * JVMOverloads added in class Text.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 _XX_04_2022
-* Enhancement bottomDescription and shadow of BottomLabel.
+* ENHANCEMENT - bottomDescription and shadow of BottomLabel.
 
 ## Release 3.2.0
 * JVMOverloads added in class Text.

--- a/app/src/androidTest/java/com/meli/android/carddrawer/app/ExampleInstrumentedTest.java
+++ b/app/src/androidTest/java/com/meli/android/carddrawer/app/ExampleInstrumentedTest.java
@@ -1,13 +1,10 @@
 package com.meli.android.carddrawer.app;
 
 import android.content.Context;
-
 import androidx.test.InstrumentationRegistry;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import static org.junit.Assert.*;
 
 /**

--- a/app/src/androidTest/java/com/meli/android/carddrawer/app/ExampleInstrumentedTest.java
+++ b/app/src/androidTest/java/com/meli/android/carddrawer/app/ExampleInstrumentedTest.java
@@ -1,7 +1,8 @@
 package com.meli.android.carddrawer.app;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
+
+import androidx.test.InstrumentationRegistry;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.Test;

--- a/app/src/main/java/com/meli/android/carddrawer/app/MainActivity.kt
+++ b/app/src/main/java/com/meli/android/carddrawer/app/MainActivity.kt
@@ -88,7 +88,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun showBottomLabel() {
-        val label = Label("A E I O U SIN COMISION")
+        val label = Label("Sin comisión")
         cardViews.forEach {
             it.view.setBottomLabel(label)
             it.view.showBottomLabel()

--- a/app/src/main/java/com/meli/android/carddrawer/app/MainActivity.kt
+++ b/app/src/main/java/com/meli/android/carddrawer/app/MainActivity.kt
@@ -88,7 +88,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun showBottomLabel() {
-        val label = Label("Sin comisión")
+        val label = Label("A E I O U SIN COMISION")
         cardViews.forEach {
             it.view.setBottomLabel(label)
             it.view.showBottomLabel()

--- a/app/src/test/java/com/meli/android/carddrawer/app/model/PixConfigurationTest.kt
+++ b/app/src/test/java/com/meli/android/carddrawer/app/model/PixConfigurationTest.kt
@@ -33,7 +33,7 @@ class PixConfigurationTest: BaseTest() {
 
     @Test
     fun `when getting imageUrl then return mercadolibre link`() {
-        val result: Boolean = pixConfiguration.imageUrl?.contains("https://mobile.mercadolibre.com") ?: false
+        val result: Boolean = pixConfiguration.imageUrl?.contains("https://http2.mlstatic.com/") ?: false
         Assert.assertTrue(result)
     }
 

--- a/carddrawer/src/main/java/com/meli/android/carddrawer/model/BottomLabel.kt
+++ b/carddrawer/src/main/java/com/meli/android/carddrawer/model/BottomLabel.kt
@@ -91,5 +91,5 @@ internal class BottomLabel @JvmOverloads constructor(
         bottomDescription.post { bottomDescription.setTextSize(TypedValue.COMPLEX_UNIT_PX, getTextPixelSize(multiplier)) }
     }
 
-    private fun getTextPixelSize(multiplier: Float) = resources.getDimension(R.dimen.card_drawer_font_size) * multiplier
+    private fun getTextPixelSize(multiplier: Float) = resources.getDimension(R.dimen.card_drawer_font_size_small) * multiplier
 }

--- a/carddrawer/src/main/java/com/meli/android/carddrawer/model/BottomLabel.kt
+++ b/carddrawer/src/main/java/com/meli/android/carddrawer/model/BottomLabel.kt
@@ -27,7 +27,6 @@ internal class BottomLabel @JvmOverloads constructor(
 
     init {
         inflate(context, R.layout.card_drawer_bottom_label, this)
-        //orientation = VERTICAL
         bottomDescription = findViewById(R.id.card_drawer_bottom_description)
     }
 
@@ -79,13 +78,8 @@ internal class BottomLabel @JvmOverloads constructor(
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
         super.onSizeChanged(w, h, oldw, oldh)
         val cardSizeMultiplier = measuredWidth / defaultBottomLabelWidth
-        val bottomLabelHeightMultiplier = (if (oldh > 0) ((h * 100f) / oldh) / 100f else cardSizeMultiplier)
 
         setUpBottomDescriptionTextSize(cardSizeMultiplier)
-        /*val containerBottomLabelParams = layoutParams
-        val height = (containerBottomLabelParams.height * bottomLabelHeightMultiplier).roundToInt()
-        containerBottomLabelParams.height = height
-        layoutParams = containerBottomLabelParams*/
     }
 
     private fun setUpBottomDescriptionTextSize(multiplier: Float) {

--- a/carddrawer/src/main/java/com/meli/android/carddrawer/model/BottomLabel.kt
+++ b/carddrawer/src/main/java/com/meli/android/carddrawer/model/BottomLabel.kt
@@ -6,6 +6,7 @@ import android.util.AttributeSet
 import android.util.TypedValue
 import android.widget.LinearLayout
 import androidx.appcompat.widget.AppCompatTextView
+import androidx.constraintlayout.widget.ConstraintLayout
 import com.meli.android.carddrawer.ColorUtils.safeParcelColor
 import com.meli.android.carddrawer.R
 import com.meli.android.carddrawer.format.CardDrawerFont
@@ -17,7 +18,7 @@ internal class BottomLabel @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
-) : LinearLayout(context, attrs, defStyleAttr) {
+) : ConstraintLayout(context, attrs, defStyleAttr) {
 
     private var bottomDescription: AppCompatTextView
     private var animation: BottomLabelAnimation? = null
@@ -26,7 +27,7 @@ internal class BottomLabel @JvmOverloads constructor(
 
     init {
         inflate(context, R.layout.card_drawer_bottom_label, this)
-        orientation = VERTICAL
+        //orientation = VERTICAL
         bottomDescription = findViewById(R.id.card_drawer_bottom_description)
     }
 
@@ -81,10 +82,10 @@ internal class BottomLabel @JvmOverloads constructor(
         val bottomLabelHeightMultiplier = (if (oldh > 0) ((h * 100f) / oldh) / 100f else cardSizeMultiplier)
 
         setUpBottomDescriptionTextSize(cardSizeMultiplier)
-        val containerBottomLabelParams = layoutParams
+        /*val containerBottomLabelParams = layoutParams
         val height = (containerBottomLabelParams.height * bottomLabelHeightMultiplier).roundToInt()
         containerBottomLabelParams.height = height
-        layoutParams = containerBottomLabelParams
+        layoutParams = containerBottomLabelParams*/
     }
 
     private fun setUpBottomDescriptionTextSize(multiplier: Float) {

--- a/carddrawer/src/main/res/layout/card_drawer_bottom_label.xml
+++ b/carddrawer/src/main/res/layout/card_drawer_bottom_label.xml
@@ -12,7 +12,6 @@
         android:id="@+id/card_drawer_bottom_description_shadow"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-
         android:background="@drawable/shadow_top" />
 
     <androidx.appcompat.widget.AppCompatTextView

--- a/carddrawer/src/main/res/layout/card_drawer_bottom_label.xml
+++ b/carddrawer/src/main/res/layout/card_drawer_bottom_label.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    tools:parentTag="android.widget.LinearLayout"
-    android:layout_height="0dp"
+    tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout"
+    android:layout_height="wrap_content"
     android:orientation="vertical"
     tools:background="@color/card_drawer_color_bottom_label">
 
@@ -11,23 +12,26 @@
         android:id="@+id/card_drawer_bottom_description_shadow"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1"
+
         android:background="@drawable/shadow_top" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/card_drawer_bottom_description"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
         android:layout_marginStart="@dimen/card_drawer_s_alternative_1_margin"
         android:layout_marginEnd="@dimen/card_drawer_s_alternative_1_margin"
         android:gravity="center"
         android:visibility="invisible"
         tools:visibility="visible"
         android:textColor="@color/card_drawer_ui_white"
-        android:textSize="@dimen/card_drawer_xxxs_text"
+        android:includeFontPadding="false"
         android:ellipsize="end"
         android:maxLines="1"
-        android:layout_weight="16"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         tools:text="Ahorro con tu banco" />
 
 </merge>

--- a/carddrawer/src/main/res/layout/card_drawer_bottom_label.xml
+++ b/carddrawer/src/main/res/layout/card_drawer_bottom_label.xml
@@ -17,7 +17,7 @@
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/card_drawer_bottom_description"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
+        android:layout_height="match_parent"
         android:layout_marginStart="@dimen/card_drawer_s_alternative_1_margin"
         android:layout_marginEnd="@dimen/card_drawer_s_alternative_1_margin"
         android:gravity="center"
@@ -27,7 +27,7 @@
         android:textSize="@dimen/card_drawer_xxxs_text"
         android:ellipsize="end"
         android:maxLines="1"
-        android:layout_weight="18"
+        android:layout_weight="16"
         tools:text="Ahorro con tu banco" />
 
 </merge>

--- a/carddrawer/src/main/res/layout/card_drawer_container_bottom_label.xml
+++ b/carddrawer/src/main/res/layout/card_drawer_container_bottom_label.xml
@@ -22,6 +22,8 @@
             android:id="@+id/card_drawer_bottom_label"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
             android:visibility="invisible"
             tools:visibility="visible"/>
 


### PR DESCRIPTION
## Motivación y Contexto

It was required to improve the 'bottomDescription' due to the text was a bit big and it was not centered horizontally.

## Descripción

- To make the text smaller I changed a dimention resourse used on *fun getTextPixelSize* from 'BottomLabel.kt'.
- To center the text I changed some properties of the TextView 'card_drawer_bottom_description' from 'card_drawer_bottom_label.xml'

## Cómo probarlo

In the TestApp, you can select a card, check 'Responsive' and 'Show Bottom Label'.

## Screenshots

https://user-images.githubusercontent.com/96031163/164747734-59c08bfa-bc59-4556-91eb-708cb1ed9a7b.mp4


https://user-images.githubusercontent.com/96031163/165332096-01c2ca8b-4261-4ba1-951a-c755bf31e45a.mp4





