### PR TITLE
Migration to API 32 (Android 12)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+  # Websec hook is MANDATORY, DO NOT comment it.
+  - repo: https://github.com/mercadolibre/fury_websec-git-hooks
+    rev: v1.0.0
+    hooks:
+      - id: pre_commit_hook
+        stages: [commit]
+      - id: post_commit_hook
+        stages: [post-commit]
+
+  # Next hooks are Code Quality hooks. 
+  # If you want them to run on each commit, uncomment them
+  # These are OPTIONAL.
+  
+  # - repo: https://github.com/mercadolibre/fury_cq-pre-commit-kotlin-test
+  #   rev: e630c993630789a6c1749457255e806ba89dac2e
+  #   hooks:
+  #     - id: ktlint
+  #       args:
+  #         - -F
+  #         - --editorconfig=.code_quality/.editorconfig
+  #     - id: detekt
+  #       args:
+  #         - -c
+  #         - .code_quality/detekt_rules.yml
+  #         - -ac

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   # Websec hook is MANDATORY, DO NOT comment it.
   - repo: https://github.com/mercadolibre/fury_websec-git-hooks
-    rev: v1.0.0
+    rev: v1.0.1
     hooks:
       - id: pre_commit_hook
         stages: [commit]

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,7 +28,7 @@ libraryVersion=3.3.0
 # Project setup
 ##################################################################################
 androidMinSdk=21
-androidTarget=30
+androidTarget=32
 androidBuildToolsVersion=30.0.2
 appCompatVersion=1.2.0
 materialVersion=1.4.0


### PR DESCRIPTION
<br><h2>  This Pull Request migrated to [API 32 (Android 12)](https://sites.google.com/mercadolibre.com/mobile/gu%C3%ADas-y-problemas/gu%C3%ADas-de-migraci%C3%B3n/migraci%C3%B3n-api-32-android).</h2>If used the libraries:<br>- androidx.work:work-runtime:2.1 --> 2.7.0<br>- androidx.browser:browser:1.0.0 --> 1.4.0<br>- com.google.android.gms:play-services-analytics:17.0.0 --> 17.0.1<br>- androidx.core:core / core-ktx:1.3.2 --> 1.6.0<br>these must be updated to migrate to Android 12, these libraries generate a breaking change, we must wait until the date they are enabled.(ENABLE LIBS)![image](https://user-images.githubusercontent.com/96055139/186246732-4f900fc9-ac57-4b3d-b706-92ad62268e8e.png)<br>- Please merge this PR if everything is green :white_check_mark:. <br>- If you have any problems or queries, contact the [Platform Update](https://meli.slack.com/archives/C03S5L8SLES)